### PR TITLE
Add UI for simulation speed and population graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# codex_first
+# Multi Agent Simulation
+
+This repository contains a simple cellular automata style simulation written in JavaScript.
+
+## Usage
+
+Open `index.html` in a web browser. Use the speed slider to adjust how fast the simulation runs. The page also displays a line chart of grass, herbivore, and carnivore counts over time. The main canvas shows grass (green), herbivores (blue), and carnivores (red). Each step, agents move randomly, eat, reproduce, or die based on their energy.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>Multi Agent Simulation</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; }
+    canvas { border: 1px solid #ccc; }
+    #controls { margin: 10px 0; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <h1>Multi Agent Simulation</h1>
+  <div id="controls">
+    <label for="speed">Speed:</label>
+    <input type="range" id="speed" min="1" max="60" value="30" />
+    <span id="speedValue">30</span> steps/sec
+  </div>
+  <canvas id="world" width="500" height="500"></canvas>
+  <h2>Population over Time</h2>
+  <canvas id="populationChart" width="500" height="200"></canvas>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,187 @@
+const canvas = document.getElementById('world');
+const ctx = canvas.getContext('2d');
+
+// speed control
+const speedInput = document.getElementById('speed');
+const speedValue = document.getElementById('speedValue');
+let speed = Number(speedInput.value);
+speedInput.addEventListener('input', () => {
+  speed = Number(speedInput.value);
+  speedValue.textContent = speedInput.value;
+});
+
+const cellSize = 10;
+const gridWidth = canvas.width / cellSize;
+const gridHeight = canvas.height / cellSize;
+
+// Environment
+const grass = [];
+const grassTimer = [];
+const grassRegrowTime = 20; // steps
+const totalCells = gridWidth * gridHeight;
+let grassCount = totalCells;
+for (let x = 0; x < gridWidth; x++) {
+  grass[x] = [];
+  grassTimer[x] = [];
+  for (let y = 0; y < gridHeight; y++) {
+    grass[x][y] = true;
+    grassTimer[x][y] = 0;
+  }
+}
+
+// Agents
+let herbivores = [];
+let carnivores = [];
+
+const initialHerbivores = 20;
+const initialCarnivores = 5;
+
+const herbivoreEnergyGainFromGrass = 4;
+const carnivoreEnergyGainFromMeat = 20;
+const herbivoreMoveCost = 1;
+const carnivoreMoveCost = 2;
+const herbivoreReproduceEnergy = 10;
+const carnivoreReproduceEnergy = 30;
+
+function randPos() {
+  return {
+    x: Math.floor(Math.random() * gridWidth),
+    y: Math.floor(Math.random() * gridHeight)
+  };
+}
+
+for (let i = 0; i < initialHerbivores; i++) {
+  herbivores.push({ ...randPos(), energy: herbivoreReproduceEnergy / 2 });
+}
+for (let i = 0; i < initialCarnivores; i++) {
+  carnivores.push({ ...randPos(), energy: carnivoreReproduceEnergy / 2 });
+}
+
+// population chart setup
+const chartCtx = document.getElementById('populationChart').getContext('2d');
+const popData = {
+  labels: [],
+  datasets: [
+    { label: 'Grass', data: [], borderColor: 'green', fill: false },
+    { label: 'Herbivores', data: [], borderColor: 'blue', fill: false },
+    { label: 'Carnivores', data: [], borderColor: 'red', fill: false }
+  ]
+};
+const popChart = new Chart(chartCtx, {
+  type: 'line',
+  data: popData,
+  options: { animation: false, scales: { y: { beginAtZero: true } } }
+});
+let stepCount = 0;
+
+function moveAgent(agent) {
+  const dx = Math.floor(Math.random() * 3) - 1;
+  const dy = Math.floor(Math.random() * 3) - 1;
+  agent.x = (agent.x + dx + gridWidth) % gridWidth;
+  agent.y = (agent.y + dy + gridHeight) % gridHeight;
+}
+
+function step() {
+  // Grass regrowth
+  for (let x = 0; x < gridWidth; x++) {
+    for (let y = 0; y < gridHeight; y++) {
+      if (!grass[x][y]) {
+        grassTimer[x][y]++;
+        if (grassTimer[x][y] >= grassRegrowTime) {
+          grass[x][y] = true;
+          grassTimer[x][y] = 0;
+          grassCount++;
+        }
+      }
+    }
+  }
+
+  // Herbivores act
+  for (let i = herbivores.length - 1; i >= 0; i--) {
+    const h = herbivores[i];
+    h.energy -= herbivoreMoveCost;
+    moveAgent(h);
+    if (grass[h.x][h.y]) {
+      grass[h.x][h.y] = false;
+      grassTimer[h.x][h.y] = 0;
+      grassCount--;
+      h.energy += herbivoreEnergyGainFromGrass;
+    }
+    if (h.energy > herbivoreReproduceEnergy) {
+      h.energy /= 2;
+      herbivores.push({ x: h.x, y: h.y, energy: h.energy });
+    }
+    if (h.energy <= 0) {
+      herbivores.splice(i, 1);
+    }
+  }
+
+  // Carnivores act
+  for (let i = carnivores.length - 1; i >= 0; i--) {
+    const c = carnivores[i];
+    c.energy -= carnivoreMoveCost;
+    moveAgent(c);
+    // check for herbivore at same position
+    const preyIndex = herbivores.findIndex(h => h.x === c.x && h.y === c.y);
+    if (preyIndex >= 0) {
+      herbivores.splice(preyIndex, 1);
+      c.energy += carnivoreEnergyGainFromMeat;
+    }
+    if (c.energy > carnivoreReproduceEnergy) {
+      c.energy /= 2;
+      carnivores.push({ x: c.x, y: c.y, energy: c.energy });
+    }
+    if (c.energy <= 0) {
+      carnivores.splice(i, 1);
+    }
+  }
+
+  // record populations
+  stepCount++;
+  popData.labels.push(stepCount);
+  popData.datasets[0].data.push(grassCount);
+  popData.datasets[1].data.push(herbivores.length);
+  popData.datasets[2].data.push(carnivores.length);
+  if (popData.labels.length > 100) {
+    popData.labels.shift();
+    popData.datasets.forEach(d => d.data.shift());
+  }
+  popChart.update();
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // draw grass
+  for (let x = 0; x < gridWidth; x++) {
+    for (let y = 0; y < gridHeight; y++) {
+      if (grass[x][y]) {
+        ctx.fillStyle = 'green';
+        ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
+      } else {
+        ctx.fillStyle = '#ccc';
+        ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
+      }
+    }
+  }
+
+  // draw herbivores
+  ctx.fillStyle = 'blue';
+  herbivores.forEach(h => {
+    ctx.fillRect(h.x * cellSize, h.y * cellSize, cellSize, cellSize);
+  });
+
+  // draw carnivores
+  ctx.fillStyle = 'red';
+  carnivores.forEach(c => {
+    ctx.fillRect(c.x * cellSize, c.y * cellSize, cellSize, cellSize);
+  });
+}
+
+function loop() {
+  step();
+  draw();
+  setTimeout(loop, 1000 / speed);
+}
+
+loop();


### PR DESCRIPTION
## Summary
- add speed slider and population chart to `index.html`
- implement speed control, grass counting, and Chart.js updates in `main.js`
- document new controls in README

## Testing
- `node --check main.js`
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684080b46d38832aa84f4c87e4b49cd4