### PR TITLE
Add adjustable simulation parameters via UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ Simply open `index.html` in a modern web browser with JavaScript enabled. The si
 
 No additional build tools or dependencies are required.
 
+### Controls
+
+Above the canvas there are sliders that let you tweak the behaviour while the simulation is running:
+
+- **Time Speed** – how many simulation steps are performed per animation frame.
+- **Herbivore Birth Cooldown** – number of steps a herbivore must wait after reproducing.
+- **Herbivore Reproduction Energy** – energy threshold required for herbivores to give birth.
+
+Adjusting these values updates the simulation immediately.
+

--- a/index.html
+++ b/index.html
@@ -10,6 +10,20 @@
 </head>
 <body>
   <h1>Multi Agent Simulation</h1>
+  <div id="controls">
+    <div>
+      <label>Time Speed: <input type="range" id="speed" min="1" max="10" value="1" /></label>
+      <span id="speedVal">1</span>
+    </div>
+    <div>
+      <label>Herbivore Birth Cooldown: <input type="range" id="herbCooldown" min="0" max="50" value="0" /></label>
+      <span id="herbCooldownVal">0</span>
+    </div>
+    <div>
+      <label>Herbivore Reproduction Energy: <input type="range" id="herbEnergy" min="5" max="30" value="10" /></label>
+      <span id="herbEnergyVal">10</span>
+    </div>
+  </div>
   <canvas id="world" width="500" height="500"></canvas>
   <script src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -29,8 +29,33 @@ const herbivoreEnergyGainFromGrass = 4;
 const carnivoreEnergyGainFromMeat = 20;
 const herbivoreMoveCost = 1;
 const carnivoreMoveCost = 2;
-const herbivoreReproduceEnergy = 10;
+let herbivoreReproduceEnergy = 10;
 const carnivoreReproduceEnergy = 30;
+
+// UI elements
+const speedInput = document.getElementById('speed');
+const speedVal = document.getElementById('speedVal');
+const herbCooldownInput = document.getElementById('herbCooldown');
+const herbCooldownVal = document.getElementById('herbCooldownVal');
+const herbEnergyInput = document.getElementById('herbEnergy');
+const herbEnergyVal = document.getElementById('herbEnergyVal');
+
+// update display values
+speedVal.textContent = speedInput.value;
+herbCooldownVal.textContent = herbCooldownInput.value;
+herbEnergyVal.textContent = herbEnergyInput.value;
+herbivoreReproduceEnergy = parseInt(herbEnergyInput.value, 10);
+
+herbEnergyInput.addEventListener('input', () => {
+  herbEnergyVal.textContent = herbEnergyInput.value;
+  herbivoreReproduceEnergy = parseInt(herbEnergyInput.value, 10);
+});
+speedInput.addEventListener('input', () => {
+  speedVal.textContent = speedInput.value;
+});
+herbCooldownInput.addEventListener('input', () => {
+  herbCooldownVal.textContent = herbCooldownInput.value;
+});
 
 function randPos() {
   return {
@@ -40,7 +65,7 @@ function randPos() {
 }
 
 for (let i = 0; i < initialHerbivores; i++) {
-  herbivores.push({ ...randPos(), energy: herbivoreReproduceEnergy / 2 });
+  herbivores.push({ ...randPos(), energy: herbivoreReproduceEnergy / 2, cooldown: 0 });
 }
 for (let i = 0; i < initialCarnivores; i++) {
   carnivores.push({ ...randPos(), energy: carnivoreReproduceEnergy / 2 });
@@ -68,18 +93,22 @@ function step() {
   }
 
   // Herbivores act
+  const reproduceEnergy = parseInt(herbEnergyInput.value, 10);
+  const reproduceCooldown = parseInt(herbCooldownInput.value, 10);
   for (let i = herbivores.length - 1; i >= 0; i--) {
     const h = herbivores[i];
     h.energy -= herbivoreMoveCost;
+    if (h.cooldown > 0) h.cooldown--;
     moveAgent(h);
     if (grass[h.x][h.y]) {
       grass[h.x][h.y] = false;
       grassTimer[h.x][h.y] = 0;
       h.energy += herbivoreEnergyGainFromGrass;
     }
-    if (h.energy > herbivoreReproduceEnergy) {
+    if (h.energy > reproduceEnergy && h.cooldown === 0) {
       h.energy /= 2;
-      herbivores.push({ x: h.x, y: h.y, energy: h.energy });
+      herbivores.push({ x: h.x, y: h.y, energy: h.energy, cooldown: reproduceCooldown });
+      h.cooldown = reproduceCooldown;
     }
     if (h.energy <= 0) {
       herbivores.splice(i, 1);
@@ -137,7 +166,10 @@ function draw() {
 }
 
 function loop() {
-  step();
+  const speed = parseInt(speedInput.value, 10);
+  for (let i = 0; i < speed; i++) {
+    step();
+  }
   draw();
   requestAnimationFrame(loop);
 }


### PR DESCRIPTION
## Summary
- add control panel to index.html with sliders for simulation speed and herbivore reproduction
- update main.js to read settings from UI
- describe new controls in README

## Testing
- `node -e "require('fs').readFile('main.js',err=>err&&console.error(err)||console.log('ok'))"`


------
https://chatgpt.com/codex/tasks/task_e_6841b896a89c832a81ebffda65f7a2ac