### PR TITLE
Add UI controls for all simulation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Simply open `index.html` in a modern web browser with JavaScript enabled. The si
 
 No additional build tools or dependencies are required.
 
+A live version is hosted on GitHub Pages: <https://your-github-username.github.io/codex_first/>
+
 ### Controls
 
 Above the canvas there are sliders that let you tweak the behaviour while the simulation is running:
@@ -61,6 +63,12 @@ Above the canvas there are sliders that let you tweak the behaviour while the si
 - **Time Speed** – how many simulation steps are performed per animation frame.
 - **Herbivore Birth Cooldown** – number of steps a herbivore must wait after reproducing.
 - **Herbivore Reproduction Energy** – energy threshold required for herbivores to give birth.
+- **Grass Regrow Time** – how many steps it takes for eaten grass to regrow.
+- **Herbivore Move Cost** – energy lost by herbivores each move.
+- **Carnivore Move Cost** – energy lost by carnivores each move.
+- **Herbivore Energy Gain** – energy herbivores receive when eating grass.
+- **Carnivore Energy Gain** – energy carnivores gain when eating a herbivore.
+- **Carnivore Reproduction Energy** – energy threshold required for carnivores to reproduce.
 
 Adjusting these values updates the simulation immediately.
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <h1>Multi Agent Simulation</h1>
   <div id="controls">
     <div>
-      <label>Time Speed: <input type="range" id="speed" min="1" max="10" value="1" /></label>
+      <label>Time Speed: <input type="range" id="speed" min="0.1" max="10" step="0.1" value="1" /></label>
       <span id="speedVal">1</span>
     </div>
     <div>
@@ -22,6 +22,30 @@
     <div>
       <label>Herbivore Reproduction Energy: <input type="range" id="herbEnergy" min="5" max="30" value="10" /></label>
       <span id="herbEnergyVal">10</span>
+    </div>
+    <div>
+      <label>Grass Regrow Time: <input type="range" id="grassRegrow" min="1" max="100" value="20" /></label>
+      <span id="grassRegrowVal">20</span>
+    </div>
+    <div>
+      <label>Herbivore Move Cost: <input type="range" id="herbMove" min="0" max="5" value="1" /></label>
+      <span id="herbMoveVal">1</span>
+    </div>
+    <div>
+      <label>Carnivore Move Cost: <input type="range" id="carnMove" min="0" max="5" value="2" /></label>
+      <span id="carnMoveVal">2</span>
+    </div>
+    <div>
+      <label>Herbivore Energy Gain: <input type="range" id="herbGain" min="1" max="10" value="4" /></label>
+      <span id="herbGainVal">4</span>
+    </div>
+    <div>
+      <label>Carnivore Energy Gain: <input type="range" id="carnGain" min="1" max="50" value="20" /></label>
+      <span id="carnGainVal">20</span>
+    </div>
+    <div>
+      <label>Carnivore Reproduction Energy: <input type="range" id="carnEnergy" min="10" max="50" value="30" /></label>
+      <span id="carnEnergyVal">30</span>
     </div>
   </div>
   <canvas id="world" width="500" height="500"></canvas>

--- a/main.js
+++ b/main.js
@@ -8,7 +8,6 @@ const gridHeight = canvas.height / cellSize;
 // Environment
 const grass = [];
 const grassTimer = [];
-const grassRegrowTime = 20; // steps
 for (let x = 0; x < gridWidth; x++) {
   grass[x] = [];
   grassTimer[x] = [];
@@ -25,10 +24,10 @@ let carnivores = [];
 const initialHerbivores = 20;
 const initialCarnivores = 5;
 
-const herbivoreEnergyGainFromGrass = 4;
-const carnivoreEnergyGainFromMeat = 20;
-const herbivoreMoveCost = 1;
-const carnivoreMoveCost = 2;
+const herbivoreEnergyGainFromGrass = 4; // default, UI overrides
+const carnivoreEnergyGainFromMeat = 20; // default, UI overrides
+const herbivoreMoveCost = 1; // default, UI overrides
+const carnivoreMoveCost = 2; // default, UI overrides
 let herbivoreReproduceEnergy = 10;
 const carnivoreReproduceEnergy = 30;
 
@@ -39,11 +38,31 @@ const herbCooldownInput = document.getElementById('herbCooldown');
 const herbCooldownVal = document.getElementById('herbCooldownVal');
 const herbEnergyInput = document.getElementById('herbEnergy');
 const herbEnergyVal = document.getElementById('herbEnergyVal');
+const grassRegrowInput = document.getElementById('grassRegrow');
+const grassRegrowVal = document.getElementById('grassRegrowVal');
+const herbMoveInput = document.getElementById('herbMove');
+const herbMoveVal = document.getElementById('herbMoveVal');
+const carnMoveInput = document.getElementById('carnMove');
+const carnMoveVal = document.getElementById('carnMoveVal');
+const herbGainInput = document.getElementById('herbGain');
+const herbGainVal = document.getElementById('herbGainVal');
+const carnGainInput = document.getElementById('carnGain');
+const carnGainVal = document.getElementById('carnGainVal');
+const carnEnergyInput = document.getElementById('carnEnergy');
+const carnEnergyVal = document.getElementById('carnEnergyVal');
+
+let speedAccumulator = 0;
 
 // update display values
 speedVal.textContent = speedInput.value;
 herbCooldownVal.textContent = herbCooldownInput.value;
 herbEnergyVal.textContent = herbEnergyInput.value;
+grassRegrowVal.textContent = grassRegrowInput.value;
+herbMoveVal.textContent = herbMoveInput.value;
+carnMoveVal.textContent = carnMoveInput.value;
+herbGainVal.textContent = herbGainInput.value;
+carnGainVal.textContent = carnGainInput.value;
+carnEnergyVal.textContent = carnEnergyInput.value;
 herbivoreReproduceEnergy = parseInt(herbEnergyInput.value, 10);
 
 herbEnergyInput.addEventListener('input', () => {
@@ -55,6 +74,24 @@ speedInput.addEventListener('input', () => {
 });
 herbCooldownInput.addEventListener('input', () => {
   herbCooldownVal.textContent = herbCooldownInput.value;
+});
+grassRegrowInput.addEventListener('input', () => {
+  grassRegrowVal.textContent = grassRegrowInput.value;
+});
+herbMoveInput.addEventListener('input', () => {
+  herbMoveVal.textContent = herbMoveInput.value;
+});
+carnMoveInput.addEventListener('input', () => {
+  carnMoveVal.textContent = carnMoveInput.value;
+});
+herbGainInput.addEventListener('input', () => {
+  herbGainVal.textContent = herbGainInput.value;
+});
+carnGainInput.addEventListener('input', () => {
+  carnGainVal.textContent = carnGainInput.value;
+});
+carnEnergyInput.addEventListener('input', () => {
+  carnEnergyVal.textContent = carnEnergyInput.value;
 });
 
 function randPos() {
@@ -79,12 +116,18 @@ function moveAgent(agent) {
 }
 
 function step() {
+  const regrowTime = parseInt(grassRegrowInput.value, 10);
+  const herbMove = parseInt(herbMoveInput.value, 10);
+  const carnMove = parseInt(carnMoveInput.value, 10);
+  const herbGain = parseInt(herbGainInput.value, 10);
+  const carnGain = parseInt(carnGainInput.value, 10);
+  const carnReproduce = parseInt(carnEnergyInput.value, 10);
   // Grass regrowth
   for (let x = 0; x < gridWidth; x++) {
     for (let y = 0; y < gridHeight; y++) {
       if (!grass[x][y]) {
         grassTimer[x][y]++;
-        if (grassTimer[x][y] >= grassRegrowTime) {
+        if (grassTimer[x][y] >= regrowTime) {
           grass[x][y] = true;
           grassTimer[x][y] = 0;
         }
@@ -97,13 +140,13 @@ function step() {
   const reproduceCooldown = parseInt(herbCooldownInput.value, 10);
   for (let i = herbivores.length - 1; i >= 0; i--) {
     const h = herbivores[i];
-    h.energy -= herbivoreMoveCost;
+    h.energy -= herbMove;
     if (h.cooldown > 0) h.cooldown--;
     moveAgent(h);
     if (grass[h.x][h.y]) {
       grass[h.x][h.y] = false;
       grassTimer[h.x][h.y] = 0;
-      h.energy += herbivoreEnergyGainFromGrass;
+      h.energy += herbGain;
     }
     if (h.energy > reproduceEnergy && h.cooldown === 0) {
       h.energy /= 2;
@@ -118,15 +161,15 @@ function step() {
   // Carnivores act
   for (let i = carnivores.length - 1; i >= 0; i--) {
     const c = carnivores[i];
-    c.energy -= carnivoreMoveCost;
+    c.energy -= carnMove;
     moveAgent(c);
     // check for herbivore at same position
     const preyIndex = herbivores.findIndex(h => h.x === c.x && h.y === c.y);
     if (preyIndex >= 0) {
       herbivores.splice(preyIndex, 1);
-      c.energy += carnivoreEnergyGainFromMeat;
+      c.energy += carnGain;
     }
-    if (c.energy > carnivoreReproduceEnergy) {
+    if (c.energy > carnReproduce) {
       c.energy /= 2;
       carnivores.push({ x: c.x, y: c.y, energy: c.energy });
     }
@@ -166,9 +209,10 @@ function draw() {
 }
 
 function loop() {
-  const speed = parseInt(speedInput.value, 10);
-  for (let i = 0; i < speed; i++) {
+  speedAccumulator += parseFloat(speedInput.value);
+  while (speedAccumulator >= 1) {
     step();
+    speedAccumulator -= 1;
   }
   draw();
   requestAnimationFrame(loop);


### PR DESCRIPTION
## Summary
- make time speed slider support sub-1 values
- expose additional parameters (grass regrow time, move costs, energy gains, carnivore reproduction energy) via HTML sliders
- update simulation logic to read values from the new sliders
- document new controls and link to GitHub Pages

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6841bd5afec4832a8e9f43d3d27fa184