### PR TITLE
Add numeric inputs for parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A live version is hosted on GitHub Pages: <https://kazuya030.github.io/codex_fir
 
 ### Controls
 
-Above the canvas there are sliders that let you tweak the behaviour while the simulation is running:
+Above the canvas there are sliders and numeric text boxes that let you tweak the behaviour while the simulation is running:
 
 - **Time Speed** – how many simulation steps are performed per animation frame.
 - **Herbivore Birth Cooldown** – number of steps a herbivore must wait after reproducing.
@@ -70,5 +70,5 @@ Above the canvas there are sliders that let you tweak the behaviour while the si
 - **Carnivore Energy Gain** – energy carnivores gain when eating a herbivore.
 - **Carnivore Reproduction Energy** – energy threshold required for carnivores to reproduce.
 
-Adjusting these values updates the simulation immediately.
+Adjusting these values updates the simulation immediately. You can either drag a slider or type a number for precise control.
 

--- a/index.html
+++ b/index.html
@@ -13,38 +13,47 @@
   <div id="controls">
     <div>
       <label>Time Speed: <input type="range" id="speed" min="0.1" max="10" step="0.1" value="1" /></label>
+      <input type="number" id="speedBox" min="0.1" max="10" step="0.1" value="1" style="width:60px" />
       <span id="speedVal">1</span>
     </div>
     <div>
       <label>Herbivore Birth Cooldown: <input type="range" id="herbCooldown" min="0" max="50" value="0" /></label>
+      <input type="number" id="herbCooldownBox" min="0" max="50" value="0" style="width:60px" />
       <span id="herbCooldownVal">0</span>
     </div>
     <div>
       <label>Herbivore Reproduction Energy: <input type="range" id="herbEnergy" min="5" max="30" value="10" /></label>
+      <input type="number" id="herbEnergyBox" min="5" max="30" value="10" style="width:60px" />
       <span id="herbEnergyVal">10</span>
     </div>
     <div>
       <label>Grass Regrow Time: <input type="range" id="grassRegrow" min="1" max="100" value="20" /></label>
+      <input type="number" id="grassRegrowBox" min="1" max="100" value="20" style="width:60px" />
       <span id="grassRegrowVal">20</span>
     </div>
     <div>
       <label>Herbivore Move Cost: <input type="range" id="herbMove" min="0" max="5" value="1" /></label>
+      <input type="number" id="herbMoveBox" min="0" max="5" value="1" style="width:60px" />
       <span id="herbMoveVal">1</span>
     </div>
     <div>
       <label>Carnivore Move Cost: <input type="range" id="carnMove" min="0" max="5" value="2" /></label>
+      <input type="number" id="carnMoveBox" min="0" max="5" value="2" style="width:60px" />
       <span id="carnMoveVal">2</span>
     </div>
     <div>
       <label>Herbivore Energy Gain: <input type="range" id="herbGain" min="1" max="10" value="4" /></label>
+      <input type="number" id="herbGainBox" min="1" max="10" value="4" style="width:60px" />
       <span id="herbGainVal">4</span>
     </div>
     <div>
       <label>Carnivore Energy Gain: <input type="range" id="carnGain" min="1" max="50" value="20" /></label>
+      <input type="number" id="carnGainBox" min="1" max="50" value="20" style="width:60px" />
       <span id="carnGainVal">20</span>
     </div>
     <div>
       <label>Carnivore Reproduction Energy: <input type="range" id="carnEnergy" min="10" max="50" value="30" /></label>
+      <input type="number" id="carnEnergyBox" min="10" max="50" value="30" style="width:60px" />
       <span id="carnEnergyVal">30</span>
     </div>
   </div>

--- a/main.js
+++ b/main.js
@@ -33,65 +33,129 @@ const carnivoreReproduceEnergy = 30;
 
 // UI elements
 const speedInput = document.getElementById('speed');
+const speedBox = document.getElementById('speedBox');
 const speedVal = document.getElementById('speedVal');
 const herbCooldownInput = document.getElementById('herbCooldown');
+const herbCooldownBox = document.getElementById('herbCooldownBox');
 const herbCooldownVal = document.getElementById('herbCooldownVal');
 const herbEnergyInput = document.getElementById('herbEnergy');
+const herbEnergyBox = document.getElementById('herbEnergyBox');
 const herbEnergyVal = document.getElementById('herbEnergyVal');
 const grassRegrowInput = document.getElementById('grassRegrow');
+const grassRegrowBox = document.getElementById('grassRegrowBox');
 const grassRegrowVal = document.getElementById('grassRegrowVal');
 const herbMoveInput = document.getElementById('herbMove');
+const herbMoveBox = document.getElementById('herbMoveBox');
 const herbMoveVal = document.getElementById('herbMoveVal');
 const carnMoveInput = document.getElementById('carnMove');
+const carnMoveBox = document.getElementById('carnMoveBox');
 const carnMoveVal = document.getElementById('carnMoveVal');
 const herbGainInput = document.getElementById('herbGain');
+const herbGainBox = document.getElementById('herbGainBox');
 const herbGainVal = document.getElementById('herbGainVal');
 const carnGainInput = document.getElementById('carnGain');
+const carnGainBox = document.getElementById('carnGainBox');
 const carnGainVal = document.getElementById('carnGainVal');
 const carnEnergyInput = document.getElementById('carnEnergy');
+const carnEnergyBox = document.getElementById('carnEnergyBox');
 const carnEnergyVal = document.getElementById('carnEnergyVal');
 
 let speedAccumulator = 0;
 
 // update display values
 speedVal.textContent = speedInput.value;
+speedBox.value = speedInput.value;
 herbCooldownVal.textContent = herbCooldownInput.value;
+herbCooldownBox.value = herbCooldownInput.value;
 herbEnergyVal.textContent = herbEnergyInput.value;
+herbEnergyBox.value = herbEnergyInput.value;
 grassRegrowVal.textContent = grassRegrowInput.value;
+grassRegrowBox.value = grassRegrowInput.value;
 herbMoveVal.textContent = herbMoveInput.value;
+herbMoveBox.value = herbMoveInput.value;
 carnMoveVal.textContent = carnMoveInput.value;
+carnMoveBox.value = carnMoveInput.value;
 herbGainVal.textContent = herbGainInput.value;
+herbGainBox.value = herbGainInput.value;
 carnGainVal.textContent = carnGainInput.value;
+carnGainBox.value = carnGainInput.value;
 carnEnergyVal.textContent = carnEnergyInput.value;
+carnEnergyBox.value = carnEnergyInput.value;
 herbivoreReproduceEnergy = parseInt(herbEnergyInput.value, 10);
 
 herbEnergyInput.addEventListener('input', () => {
   herbEnergyVal.textContent = herbEnergyInput.value;
   herbivoreReproduceEnergy = parseInt(herbEnergyInput.value, 10);
+  herbEnergyBox.value = herbEnergyInput.value;
+});
+herbEnergyBox.addEventListener('input', () => {
+  herbEnergyInput.value = herbEnergyBox.value;
+  herbEnergyVal.textContent = herbEnergyBox.value;
+  herbivoreReproduceEnergy = parseInt(herbEnergyBox.value, 10);
 });
 speedInput.addEventListener('input', () => {
   speedVal.textContent = speedInput.value;
+  speedBox.value = speedInput.value;
+});
+speedBox.addEventListener('input', () => {
+  speedInput.value = speedBox.value;
+  speedVal.textContent = speedBox.value;
 });
 herbCooldownInput.addEventListener('input', () => {
   herbCooldownVal.textContent = herbCooldownInput.value;
+  herbCooldownBox.value = herbCooldownInput.value;
+});
+herbCooldownBox.addEventListener('input', () => {
+  herbCooldownInput.value = herbCooldownBox.value;
+  herbCooldownVal.textContent = herbCooldownBox.value;
 });
 grassRegrowInput.addEventListener('input', () => {
   grassRegrowVal.textContent = grassRegrowInput.value;
+  grassRegrowBox.value = grassRegrowInput.value;
+});
+grassRegrowBox.addEventListener('input', () => {
+  grassRegrowInput.value = grassRegrowBox.value;
+  grassRegrowVal.textContent = grassRegrowBox.value;
 });
 herbMoveInput.addEventListener('input', () => {
   herbMoveVal.textContent = herbMoveInput.value;
+  herbMoveBox.value = herbMoveInput.value;
+});
+herbMoveBox.addEventListener('input', () => {
+  herbMoveInput.value = herbMoveBox.value;
+  herbMoveVal.textContent = herbMoveBox.value;
 });
 carnMoveInput.addEventListener('input', () => {
   carnMoveVal.textContent = carnMoveInput.value;
+  carnMoveBox.value = carnMoveInput.value;
+});
+carnMoveBox.addEventListener('input', () => {
+  carnMoveInput.value = carnMoveBox.value;
+  carnMoveVal.textContent = carnMoveBox.value;
 });
 herbGainInput.addEventListener('input', () => {
   herbGainVal.textContent = herbGainInput.value;
+  herbGainBox.value = herbGainInput.value;
+});
+herbGainBox.addEventListener('input', () => {
+  herbGainInput.value = herbGainBox.value;
+  herbGainVal.textContent = herbGainBox.value;
 });
 carnGainInput.addEventListener('input', () => {
   carnGainVal.textContent = carnGainInput.value;
+  carnGainBox.value = carnGainInput.value;
+});
+carnGainBox.addEventListener('input', () => {
+  carnGainInput.value = carnGainBox.value;
+  carnGainVal.textContent = carnGainBox.value;
 });
 carnEnergyInput.addEventListener('input', () => {
   carnEnergyVal.textContent = carnEnergyInput.value;
+  carnEnergyBox.value = carnEnergyInput.value;
+});
+carnEnergyBox.addEventListener('input', () => {
+  carnEnergyInput.value = carnEnergyBox.value;
+  carnEnergyVal.textContent = carnEnergyBox.value;
 });
 
 function randPos() {


### PR DESCRIPTION
## Summary
- enable numeric text boxes beside sliders to control parameters
- synchronize sliders with text boxes in `main.js`
- document new controls in README

## Testing
- `node -c main.js`


------
https://chatgpt.com/codex/tasks/task_e_6841c0550f1c832a8d4ac41619fb0f28