### PR TITLE
Add realtime population graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,8 @@
     </div>
   </div>
   <canvas id="world" width="500" height="500"></canvas>
+  <canvas id="populationChart" width="500" height="200"></canvas>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -62,6 +62,43 @@ const carnEnergyVal = document.getElementById('carnEnergyVal');
 
 let speedAccumulator = 0;
 
+let stepCount = 0;
+const chartCtx = document.getElementById('populationChart').getContext('2d');
+const maxDataPoints = 100;
+const chart = new Chart(chartCtx, {
+  type: 'line',
+  data: {
+    labels: [],
+    datasets: [
+      {
+        label: 'Grass',
+        data: [],
+        borderColor: 'green',
+        fill: false
+      },
+      {
+        label: 'Herbivores',
+        data: [],
+        borderColor: 'blue',
+        fill: false
+      }
+    ]
+  },
+  options: {
+    animation: false,
+    responsive: false,
+    scales: {
+      x: {
+        title: { display: true, text: 'Time' }
+      },
+      y: {
+        title: { display: true, text: 'Count' },
+        beginAtZero: true
+      }
+    }
+  }
+});
+
 // update display values
 speedVal.textContent = speedInput.value;
 speedBox.value = speedInput.value;
@@ -196,6 +233,27 @@ function step() {
       carnivores.splice(i, 1);
     }
   }
+
+  stepCount++;
+  updateChart();
+}
+
+function updateChart() {
+  let grassCount = 0;
+  for (let x = 0; x < gridWidth; x++) {
+    for (let y = 0; y < gridHeight; y++) {
+      if (grass[x][y]) grassCount++;
+    }
+  }
+  chart.data.labels.push(stepCount.toString());
+  chart.data.datasets[0].data.push(grassCount);
+  chart.data.datasets[1].data.push(herbivores.length);
+  if (chart.data.labels.length > maxDataPoints) {
+    chart.data.labels.shift();
+    chart.data.datasets[0].data.shift();
+    chart.data.datasets[1].data.shift();
+  }
+  chart.update();
 }
 
 function draw() {


### PR DESCRIPTION
## Summary
- add population chart canvas to `index.html` and include Chart.js
- show grass and herbivore counts over time with a scrolling line chart

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841c7309de4832aaec2c6f08e13bcb1