### PR TITLE
Add simulation control buttons and center graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <style>
     body { font-family: sans-serif; text-align: center; }
     canvas { border: 1px solid #ccc; }
+    #populationChart { display: block; margin: 0 auto; }
   </style>
 </head>
 <body>
@@ -56,6 +57,11 @@
       <input type="number" id="carnEnergyBox" min="10" max="50" value="30" style="width:60px" />
       <span id="carnEnergyVal">30</span>
     </div>
+  </div>
+  <div id="simButtons">
+    <button id="pauseBtn">Pause</button>
+    <button id="resumeBtn">Resume</button>
+    <button id="resetBtn">Reset</button>
   </div>
   <canvas id="world" width="500" height="500"></canvas>
   <canvas id="populationChart" width="500" height="200"></canvas>

--- a/main.js
+++ b/main.js
@@ -59,6 +59,11 @@ const carnGainVal = document.getElementById('carnGainVal');
 const carnEnergyInput = document.getElementById('carnEnergy');
 const carnEnergyBox = document.getElementById('carnEnergyBox');
 const carnEnergyVal = document.getElementById('carnEnergyVal');
+const pauseBtn = document.getElementById('pauseBtn');
+const resumeBtn = document.getElementById('resumeBtn');
+const resetBtn = document.getElementById('resetBtn');
+
+let running = true;
 
 let speedAccumulator = 0;
 
@@ -157,12 +162,29 @@ function randPos() {
   };
 }
 
-for (let i = 0; i < initialHerbivores; i++) {
-  herbivores.push({ ...randPos(), energy: herbivoreReproduceEnergy / 2, cooldown: 0 });
+function initSimulation() {
+  for (let x = 0; x < gridWidth; x++) {
+    for (let y = 0; y < gridHeight; y++) {
+      grass[x][y] = true;
+      grassTimer[x][y] = 0;
+    }
+  }
+  herbivores = [];
+  for (let i = 0; i < initialHerbivores; i++) {
+    herbivores.push({ ...randPos(), energy: herbivoreReproduceEnergy / 2, cooldown: 0 });
+  }
+  carnivores = [];
+  for (let i = 0; i < initialCarnivores; i++) {
+    carnivores.push({ ...randPos(), energy: carnivoreReproduceEnergy / 2 });
+  }
+  stepCount = 0;
+  speedAccumulator = 0;
+  chart.data.labels = [];
+  chart.data.datasets.forEach(ds => ds.data = []);
+  chart.update();
 }
-for (let i = 0; i < initialCarnivores; i++) {
-  carnivores.push({ ...randPos(), energy: carnivoreReproduceEnergy / 2 });
-}
+
+initSimulation();
 
 function moveAgent(agent) {
   const dx = Math.floor(Math.random() * 3) - 1;
@@ -286,13 +308,19 @@ function draw() {
 }
 
 function loop() {
-  speedAccumulator += parseFloat(speedInput.value);
-  while (speedAccumulator >= 1) {
-    step();
-    speedAccumulator -= 1;
+  if (running) {
+    speedAccumulator += parseFloat(speedInput.value);
+    while (speedAccumulator >= 1) {
+      step();
+      speedAccumulator -= 1;
+    }
   }
   draw();
   requestAnimationFrame(loop);
 }
+
+pauseBtn.addEventListener('click', () => { running = false; });
+resumeBtn.addEventListener('click', () => { running = true; });
+resetBtn.addEventListener('click', () => { initSimulation(); });
 
 loop();


### PR DESCRIPTION
## Summary
- add Pause/Resume/Reset controls next to the canvas
- implement pause, resume and reset logic in `main.js`
- reset the chart when the simulation resets
- center the population chart canvas

## Testing
- `node -c main.js`
- `node main.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841ca4808d0832a8e79c2e80dedb788